### PR TITLE
tests: Fix brew style yoheimuta/protolint Error

### DIFF
--- a/Formula/protolint.rb
+++ b/Formula/protolint.rb
@@ -37,7 +37,7 @@ class Protolint < Formula
   end
 
   test do
-    system "#{bin}/protolint version"
-    system "#{bin}/protoc-gen-protolint version"
+    system "#{bin}/protolint", "version"
+    system "#{bin}/protoc-gen-protolint", "version"
   end
 end


### PR DESCRIPTION
ref. https://github.com/yoheimuta/homebrew-protolint/runs/3532805600

```
==> brew style yoheimuta/protolint
==> FAILED
/usr/local/Homebrew/Library/Taps/yoheimuta/homebrew-protolint/Formula/protolint.rb:40:12: C: [Correctable] Separate system commands into "#{bin}/protolint", "version"
    system "#{bin}/protolint version"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/Homebrew/Library/Taps/yoheimuta/homebrew-protolint/Formula/protolint.rb:41:12: C: [Correctable] Separate system commands into "#{bin}/protoc-gen-protolint", "version"
    system "#{bin}/protoc-gen-protolint version"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 2 offenses detected, 2 offenses auto-correctable
Error: Separate `system` commands into `"#{bin}/protolint", "version"`
Error: Separate `system` commands into `"#{bin}/protoc-gen-protolint", "version"`
```